### PR TITLE
Changed svg padding for centering arrows

### DIFF
--- a/src/react-scroll-up-button.js
+++ b/src/react-scroll-up-button.js
@@ -105,7 +105,7 @@ export default class ScrollUpButton extends React.Component {
           strokeWidth: 0,
           stroke: 'white',
           fill: 'white',
-          paddingLeft: 10,
+          paddingLeft: 13,
         },
         ToggledStyle: {
           opacity: 1,


### PR DESCRIPTION
Button arrows are not centered, so i just changed SvgStyle's paddingLeft rule from 10to 13 to center it.